### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dockerized Jenkins - Custom
 
-[![Build Status](https://travis-ci.org/HearstAT/docker-jenkins.svg?branch=master)](https://travis-ci.org/HearstAT/docker-jenkins) [![GitHub release](https://img.shields.io/github/release/hearstat/docker-jenkins.svg?maxAge=2592000)](https://github.com/hearstat/docker-jenkins/releases) [![Docker Automated build](https://img.shields.io/docker/automated/hearstat/jenkins.svg?maxAge=2592000)](https://hub.docker.com/r/hearstat/jenkins/) [![Docker Stars](https://img.shields.io/docker/stars/hearstat/jenkins.svg?maxAge=2592000)](https://hub.docker.com/r/hearstat/jenkins/) [![Docker Pulls](https://img.shields.io/docker/pulls/hearstat/jenkins.svg?maxAge=2592000)](https://hub.docker.com/r/hearstat/jenkins/)
+[![Build Status](https://travis-ci.org/HearstAT/docker-jenkins.svg?branch=master)](https://travis-ci.org/HearstAT/docker-jenkins) [![GitHub release](https://img.shields.io/github/release/hearstat/docker-jenkins.svg?maxAge=2592000)](https://github.com/hearstat/docker-jenkins/releases) [![Docker Automated build](https://img.shields.io/docker/automated/hearstat/jenkins.svg?maxAge=2592000)](https://hub.docker.com/r/hearstat/jenkins/) [![Docker Stars](https://img.shields.io/docker/stars/hearstat/jenkins.svg?maxAge=2592000)](https://hub.docker.com/r/hearstat/jenkins/) [![Docker Pulls](https://img.shields.io/docker/pulls/hearstat/jenkins.svg?maxAge=2592000)](https://hub.docker.com/r/hearstat/jenkins/) [![](https://images.microbadger.com/badges/image/hearstat/jenkins.svg)](https://microbadger.com/images/hearstat/jenkins "Get your own image badge on microbadger.com")
 
 
 The Jenkins Continuous Integration and Delivery server.
@@ -59,3 +59,4 @@ Plugins are installed via
 `/usr/local/bin/install-plugins.sh $(cat /plugins.txt)`
 
 Edit the [plugins.txt](plugins.txt) in the repo to install more at build time.
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [hearstat/jenkins](https://hub.docker.com/r/hearstat/jenkins/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/hearstat/jenkins).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/hearstat/jenkins.svg)](https://microbadger.com/images/hearstat/jenkins)
